### PR TITLE
Add optional author element to Item

### DIFF
--- a/Source/Suin/RSSWriter/Item.php
+++ b/Source/Suin/RSSWriter/Item.php
@@ -107,15 +107,16 @@ class Item implements \Suin\RSSWriter\ItemInterface
 		return $this;
 	}
 
-    /**
-     * Set the author
-     * @param string $author Email of item author
-     * @return $this
-     */
-    public function author($author) {
-        $this->author = $author;
-        return $this;
-    }
+	/**
+	 * Set the author
+	 * @param string $author Email of item author
+	 * @return $this
+	 */
+	public function author($author)
+	{
+		$this->author = $author;
+		return $this;
+	}
 
     /**
 	 * Append item to the channel
@@ -177,9 +178,10 @@ class Item implements \Suin\RSSWriter\ItemInterface
             }
 		}
 
-        if ( ! empty($this->author) ) {
-            $xml->addChild('author', $this->author);
-        }
+		if ( ! empty($this->author) )
+		{
+			$xml->addChild('author', $this->author);
+		}
 
 		return $xml;
 	}

--- a/Source/Suin/RSSWriter/ItemInterface.php
+++ b/Source/Suin/RSSWriter/ItemInterface.php
@@ -60,12 +60,12 @@ interface ItemInterface
 	 */
 	public function enclosure($url, $length = 0, $type = 'audio/mpeg');
 
-    /**
-     * Set the author
-     * @param string $author Email of item author
-     * @return $this
-     */
-    public function author($author);
+	/**
+	 * Set the author
+	 * @param string $author Email of item author
+	 * @return $this
+	 */
+	public function author($author);
 
 	/**
 	 * Append item to the channel

--- a/Tests/Suin/RSSWriter/ItemTest.php
+++ b/Tests/Suin/RSSWriter/ItemTest.php
@@ -97,13 +97,13 @@ class ItemTest extends \XoopsUnit\TestCase
 		$this->assertAttributeSame($enclosure, 'enclosure', $item);
 	}
 
-    public function testAuthor()
-    {
-        $author = uniqid();
-        $item = new Item();
-        $this->assertSame($item, $item->author($author));
-        $this->assertAttributeSame($author, 'author', $item);
-    }
+	public function testAuthor()
+	{
+		$author = uniqid();
+		$item = new Item();
+		$this->assertSame($item, $item->author($author));
+		$this->assertAttributeSame($author, 'author', $item);
+	}
 
 	public function testAsXML()
 	{
@@ -125,7 +125,7 @@ class ItemTest extends \XoopsUnit\TestCase
                 'url'    => 'http://link-to-audio-file.com/test.mp3',
                 'length' => 4992,
                 'type'   => 'audio/mpeg'),
-            'author' => 'Hidehito Nozawa aka Suin'
+			'author' => 'Hidehito Nozawa aka Suin'
 		);
 
 		$item = new Item();


### PR DESCRIPTION
This should be a simple addition to make the author element available on an `Item`. I believe author is optional according to [RSS 2.0](http://validator.w3.org/feed/docs/rss2.html). 

`ItemTest` is updated to include the new element as well.

Let me know how this looks! Thanks.
