### PR TITLE
Allow custom node elements

### DIFF
--- a/src/Suin/RSSWriter/ItemInterface.php
+++ b/src/Suin/RSSWriter/ItemInterface.php
@@ -76,6 +76,14 @@ interface ItemInterface
     public function appendTo(ChannelInterface $channel);
 
     /**
+     * @param string $tagName
+     * @param null $content
+     * @param array $options
+     * @return $this
+     */
+    public function customElement($tagName, $content = null, $options = array());
+
+    /**
      * Return XML object
      * @return \Suin\RSSWriter\SimpleXMLElement
      */

--- a/tests/Suin/RSSWriter/ItemTest.php
+++ b/tests/Suin/RSSWriter/ItemTest.php
@@ -251,4 +251,95 @@ class ItemTest extends TestCase
 
         $this->assertSame($expect, $item->asXML()->asXML());
     }
+
+    public function testCustomElement()
+    {
+        $item = new Item();
+        $this->assertSame($item, $item->customElement('testNode', 'testValue'));
+    }
+
+    public function testTransformCustomElement()
+    {
+        $data = [
+            'title'       => "Venice Film Festival",
+            'url'         => 'http://nytimes.com/2004/12/07FEST.html',
+            'description' => "Some of the most heated chatter at the Venice Film Festival this week was about the way that the arrival of the stars at the Palazzo del Cinema was being staged.",
+        ];
+
+        $item = new Item();
+
+        foreach ($data as $key => $value) {
+            $this->reveal($item)->attr($key, $value);
+        }
+        $item->customElement('testNode', 'testValue');
+
+        $expect = "
+        <item>
+            <title>{$data['title']}</title>
+            <link>{$data['url']}</link>
+            <description>{$data['description']}</description>
+            <testNode>testValue</testNode>
+        </item>
+        ";
+
+        $this->assertXmlStringEqualsXmlString($expect, $item->asXML()->asXML());
+    }
+
+    public function testTransformCustomElement_with_namespace()
+    {
+        $data = [
+            'title'       => "Venice Film Festival",
+            'url'         => 'http://nytimes.com/2004/12/07FEST.html',
+            'description' => "Some of the most heated chatter at the Venice Film Festival this week was about the way that the arrival of the stars at the Palazzo del Cinema was being staged.",
+        ];
+
+        $item = new Item();
+
+        foreach ($data as $key => $value) {
+            $this->reveal($item)->attr($key, $value);
+        }
+        $item->customElement('content:encoded', 'testValue', array(
+            'namespace' => 'http://purl.org/rss/1.0/modules/content/',
+        ));
+
+        $expect = "
+        <item>
+            <title>{$data['title']}</title>
+            <link>{$data['url']}</link>
+            <description>{$data['description']}</description>
+            <content:encoded xmlns:content=\"http://purl.org/rss/1.0/modules/content/\">testValue</content:encoded>
+        </item>
+        ";
+
+        $this->assertXmlStringEqualsXmlString($expect, $item->asXML()->asXML());
+    }
+
+    public function testTransformCustomElement_with_cdata()
+    {
+        $data = [
+            'title'       => "Venice Film Festival",
+            'url'         => 'http://nytimes.com/2004/12/07FEST.html',
+            'description' => "Some of the most heated chatter at the Venice Film Festival this week was about the way that the arrival of the stars at the Palazzo del Cinema was being staged.",
+        ];
+
+        $item = new Item();
+
+        foreach ($data as $key => $value) {
+            $this->reveal($item)->attr($key, $value);
+        }
+        $item->customElement('content', 'testValue', array(
+            'cdata' => true
+        ));
+
+        $expect = "
+        <item>
+            <title>{$data['title']}</title>
+            <link>{$data['url']}</link>
+            <description>{$data['description']}</description>
+            <content><![CDATA[testValue]]></content>
+        </item>
+        ";
+
+        $this->assertXmlStringEqualsXmlString($expect, $item->asXML()->asXML());
+    }
 }


### PR DESCRIPTION
Q |	A
--- | ---
Branch |	master
Bug fix?|	no
New feature?	| yes
BC breaks?|	no
Deprecations?	|no
Tests pass?| yes
Fixed tickets|none

This PR allows custom RSS node elements within the feed.
The original intention was to create a feed which complies to [Facebook Instant Article reference](https://developers.facebook.com/docs/instant-articles/publishing) which requires a `content:encoded` element.

Usage:
```php
$feedItem = new Item();
$feedItem
  ->title('Item title')

  // custom <content:encoded> node
  ->customElement('content:encoded', 'node value', array(
    // wrap content in CDATA tags (optional)
	'cdata' => true, 			
	
	// custom namespace (optional)
    'namespace' => 'http://purl.org/rss/1.0/modules/content/', 
  ))

  // custom <modDate> node
  ->customElement('modDate', (new \DateTime())->format(DATE_RSS));
```