### PR TITLE
Additional TravisCI PHP version test (php-master)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 sudo: false
+
 language: php
+
 php:
   - 5.4
   - 5.5
   - 5.6
   - 7.0
+  - master
   - hhvm
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: master
 
 before_script:
   - cd tests


### PR DESCRIPTION
Include PHP `master` version to detect upcoming warnings/errors.
The `master` version is allowed to fail the TravisCI tests, `fast_finish` is now enabled.