### PR TITLE
Fix: Ignore composer.lock and vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 .phpmake
 .DS_Store
+vendor/
+composer.lock


### PR DESCRIPTION
This PR

* [x] adds `composer.lock` and `vendor` to `.gitignore`