### PR TITLE
Fix: Use one composer.json only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ matrix:
   allow_failures:
     - php: master
 
-before_script:
-  - cd tests
-  - composer install -n
+install:
+  - composer install --prefer-dist
 
-script: phpunit --coverage-text --configuration phpunit.xml.dist
+script:
+  - vendor/bin/phpunit --coverage-text --configuration tests/phpunit.xml.dist
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,11 @@
   "require": {
     "php": ">=5.4.0"
   },
+  "require-dev": {
+    "EHER/PHPUnit": ">=1.6",
+    "mockery/mockery": ">=0.7.2",
+    "suin/xoopsunit": ">=1.2"
+  },
   "autoload": {
     "psr-0": {
       "Suin\\RSSWriter": "src"

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -1,8 +1,0 @@
-{
-  "require": {
-    "php": ">=5.4.0",
-    "EHER/PHPUnit": ">=1.6",
-    "suin/xoopsunit": ">=1.2",
-    "mockery/mockery": ">=0.7.2"
-  }
-}


### PR DESCRIPTION
This PR

* [x] merges `tests/composer.json` into `composer.json`
* [x] uses `phpunit/phpunit` as installed with `composer` on Travis