### PR TITLE
add creator field to Item

### DIFF
--- a/examples/simple-feed.php
+++ b/examples/simple-feed.php
@@ -32,7 +32,8 @@ $item
     ->description('<div>Blog body</div>')
     ->contentEncoded('<div>Blog body</div>')
     ->url('http://blog.example.com/2012/08/21/blog-entry/')
-    ->author('John Smith')
+    ->author('john@smith.com')
+    ->creator('John Smith')
     ->pubDate(strtotime('Tue, 21 Aug 2012 19:50:37 +0900'))
     ->guid('http://blog.example.com/2012/08/21/blog-entry/', true)
     ->preferCdata(true) // By this, title and description become CDATA wrapped HTML.

--- a/src/Suin/RSSWriter/Item.php
+++ b/src/Suin/RSSWriter/Item.php
@@ -38,6 +38,9 @@ class Item implements ItemInterface
     /** @var string */
     protected $author;
 
+    /** @var string */
+    protected $creator;
+
     protected $preferCdata = false;
 
     public function title($title)
@@ -92,6 +95,12 @@ class Item implements ItemInterface
     public function author($author)
     {
         $this->author = $author;
+        return $this;
+    }
+
+    public function creator($creator)
+    {
+        $this->creator = $creator;
         return $this;
     }
 
@@ -161,6 +170,10 @@ class Item implements ItemInterface
 
         if (!empty($this->author)) {
             $xml->addChild('author', $this->author);
+        }
+
+        if (!empty($this->creator)) {
+            $xml->addChild('dc:creator', $this->creator,"http://purl.org/dc/elements/1.1/");
         }
 
         return $xml;


### PR DESCRIPTION
The <author> tag is only supposed to contain the author's email address.
The author's name should go in a dc:creator tag. See
http://www.lowter.com/blogs/2008/2/9/rss-dccreator-author

This adds a `creator` property to the Item class, and amends the example
to set both author and creator.