### PR TITLE
add feed_url property

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $channel
     ->title('Channel Title')
     ->description('Channel Description')
     ->url('http://blog.example.com')
+    ->feedUrl('http://blog.example.com/rss')
     ->language('en-US')
     ->copyright('Copyright 2012, Foo Bar')
     ->pubDate(strtotime('Tue, 21 Aug 2012 19:50:37 +0900'))

--- a/examples/simple-feed.php
+++ b/examples/simple-feed.php
@@ -17,7 +17,7 @@ $channel
     ->title('Channel Title')
     ->description('Channel Description')
     ->url('http://blog.example.com')
-    ->feed_url('http://blog.example.com/rss')
+    ->feedUrl('http://blog.example.com/rss')
     ->language('en-US')
     ->copyright('Copyright 2012, Foo Bar')
     ->pubDate(strtotime('Tue, 21 Aug 2012 19:50:37 +0900'))

--- a/examples/simple-feed.php
+++ b/examples/simple-feed.php
@@ -17,6 +17,7 @@ $channel
     ->title('Channel Title')
     ->description('Channel Description')
     ->url('http://blog.example.com')
+    ->feed_url('http://blog.example.com/rss')
     ->language('en-US')
     ->copyright('Copyright 2012, Foo Bar')
     ->pubDate(strtotime('Tue, 21 Aug 2012 19:50:37 +0900'))

--- a/src/Suin/RSSWriter/Channel.php
+++ b/src/Suin/RSSWriter/Channel.php
@@ -14,6 +14,9 @@ class Channel implements ChannelInterface
     /** @var string */
     protected $url;
 
+    /** @var feed_url */
+    protected $feed_url;
+
     /** @var string */
     protected $description;
 
@@ -57,6 +60,17 @@ class Channel implements ChannelInterface
     public function url($url)
     {
         $this->url = $url;
+        return $this;
+    }
+
+    /**
+     * Set URL of this feed
+     * @param string $url
+     * @return $this;
+     */
+    public function feed_url($url)
+    {
+        $this->feed_url = $url;
         return $this;
     }
 
@@ -179,6 +193,13 @@ class Channel implements ChannelInterface
         $xml->addChild('title', $this->title);
         $xml->addChild('link', $this->url);
         $xml->addChild('description', $this->description);
+
+        if($this->feed_url !== null) {
+            $link = $xml->addChild('atom:link', '', "http://www.w3.org/2005/Atom");
+            $link->addAttribute('href',$this->feed_url);
+            $link->addAttribute('type','application/rss+xml');
+            $link->addAttribute('rel','self');
+        }
 
         if ($this->language !== null) {
             $xml->addChild('language', $this->language);

--- a/src/Suin/RSSWriter/Channel.php
+++ b/src/Suin/RSSWriter/Channel.php
@@ -14,8 +14,8 @@ class Channel implements ChannelInterface
     /** @var string */
     protected $url;
 
-    /** @var feed_url */
-    protected $feed_url;
+    /** @var feedUrl */
+    protected $feedUrl;
 
     /** @var string */
     protected $description;
@@ -68,9 +68,9 @@ class Channel implements ChannelInterface
      * @param string $url
      * @return $this;
      */
-    public function feed_url($url)
+    public function feedUrl($url)
     {
-        $this->feed_url = $url;
+        $this->feedUrl = $url;
         return $this;
     }
 
@@ -194,9 +194,9 @@ class Channel implements ChannelInterface
         $xml->addChild('link', $this->url);
         $xml->addChild('description', $this->description);
 
-        if($this->feed_url !== null) {
+        if($this->feedUrl !== null) {
             $link = $xml->addChild('atom:link', '', "http://www.w3.org/2005/Atom");
-            $link->addAttribute('href',$this->feed_url);
+            $link->addAttribute('href',$this->feedUrl);
             $link->addAttribute('type','application/rss+xml');
             $link->addAttribute('rel','self');
         }


### PR DESCRIPTION
The W3C feed validator recommends adding an atom:link tag with the URL
of the feed itself.

This adds a feed_url property to Channel which is used in an atom:link
tag.