### PR TITLE
Extend Feed to support CSS style sheet specification

### DIFF
--- a/src/Suin/RSSWriter/Feed.php
+++ b/src/Suin/RSSWriter/Feed.php
@@ -13,6 +13,24 @@ class Feed implements FeedInterface
     /** @var ChannelInterface[] */
     protected $channels = [];
 
+    protected $feed_styles = [];
+
+    /**
+     * Add Style sheet
+     * @param string  $style_url
+     * @param string  $media  (defaults to 'screen')
+     * @return $this
+     */
+    public function addStyle($style_url, $media = 'screen'){
+      if( !empty($style_url) ){
+	debug("Adding Style: $style_url");
+	$this->feed_styles[] = [ $style_url, $media ];
+      }
+
+      return $this;
+    }
+
+      
     /**
      * Add channel
      * @param ChannelInterface $channel
@@ -28,17 +46,33 @@ class Feed implements FeedInterface
      * Render XML
      * @return string
      */
-    public function render()
-    {
-        $xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8" ?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" />', LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_ERR_FATAL);
+    public function render(){
 
-        foreach ($this->channels as $channel) {
+      $xml = new SimpleXMLElement("<?xml version=\"1.0\" encoding=\"UTF-8\" ?><rss version=\"2.0\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\" xmlns:atom=\"http://www.w3.org/2005/Atom\" />",
+				  LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_ERR_FATAL);
+
+
+      foreach ($this->channels as $channel) {
             $toDom = dom_import_simplexml($xml);
+	    debug("toDom: " . print_r($toDom, true) );
             $fromDom = dom_import_simplexml($channel->asXML());
             $toDom->appendChild($toDom->ownerDocument->importNode($fromDom, true));
         }
 
         $dom = new DOMDocument('1.0', 'UTF-8');
+
+	if( count($this->feed_styles) > 0 ){
+	  foreach( $this->feed_styles as $info ){
+	    $url = $info[0];
+	    $media = $info[1];
+	    debug("Feed_Style: " . $url);
+	    $xslt = $dom->createProcessingInstruction('xml-stylesheet', "type=\"text/css\" media=\"{$media}\" href=\"{$url}\" ");
+	    $dom->appendChild($xslt);
+	  }
+	}
+
+	debug("XML: " . print_r(dom_import_simplexml($xml), true) );
+
         $dom->appendChild($dom->importNode(dom_import_simplexml($xml), true));
         $dom->formatOutput = true;
         return $dom->saveXML();

--- a/src/Suin/RSSWriter/Feed.php
+++ b/src/Suin/RSSWriter/Feed.php
@@ -13,7 +13,7 @@ class Feed implements FeedInterface
     /** @var ChannelInterface[] */
     protected $channels = [];
 
-    protected $feed_styles = [];
+    protected $feedStyles = [];
 
     /**
      * Add Style sheet
@@ -23,8 +23,7 @@ class Feed implements FeedInterface
      */
     public function addStyle($style_url, $media = 'screen'){
       if( !empty($style_url) ){
-	debug("Adding Style: $style_url");
-	$this->feed_styles[] = [ $style_url, $media ];
+	$this->feedStyles[] = [ $style_url, $media ];
       }
 
       return $this;
@@ -54,24 +53,20 @@ class Feed implements FeedInterface
 
       foreach ($this->channels as $channel) {
             $toDom = dom_import_simplexml($xml);
-	    debug("toDom: " . print_r($toDom, true) );
             $fromDom = dom_import_simplexml($channel->asXML());
             $toDom->appendChild($toDom->ownerDocument->importNode($fromDom, true));
         }
 
         $dom = new DOMDocument('1.0', 'UTF-8');
 
-	if( count($this->feed_styles) > 0 ){
-	  foreach( $this->feed_styles as $info ){
+	if( count($this->feedStyles) > 0 ){
+	  foreach( $this->feedStyles as $info ){
 	    $url = $info[0];
 	    $media = $info[1];
-	    debug("Feed_Style: " . $url);
 	    $xslt = $dom->createProcessingInstruction('xml-stylesheet', "type=\"text/css\" media=\"{$media}\" href=\"{$url}\" ");
 	    $dom->appendChild($xslt);
 	  }
 	}
-
-	debug("XML: " . print_r(dom_import_simplexml($xml), true) );
 
         $dom->appendChild($dom->importNode(dom_import_simplexml($xml), true));
         $dom->formatOutput = true;

--- a/src/Suin/RSSWriter/Feed.php
+++ b/src/Suin/RSSWriter/Feed.php
@@ -45,7 +45,8 @@ class Feed implements FeedInterface
      * Render XML
      * @return string
      */
-    public function render(){
+    public function render()
+    {
 
       $xml = new SimpleXMLElement("<?xml version=\"1.0\" encoding=\"UTF-8\" ?><rss version=\"2.0\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\" xmlns:atom=\"http://www.w3.org/2005/Atom\" />",
 				  LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_ERR_FATAL);

--- a/src/Suin/RSSWriter/FeedInterface.php
+++ b/src/Suin/RSSWriter/FeedInterface.php
@@ -11,9 +11,17 @@ interface FeedInterface
     /**
      * Add channel
      * @param ChannelInterface $channel
-     * @return $thisJ
+     * @return $this
      */
     public function addChannel(ChannelInterface $channel);
+
+    /**
+     * Add Style sheet
+     * @param string  $style_url
+     * @param string  $media  (defaults to 'screen')
+     * @return $this
+     */
+    public function addStyle($style_url, $media);
 
     /**
      * Render XML


### PR DESCRIPTION
Hello Suin,
  Thank you for your useful library.
   Are you interested in supporting CSS Style sheets for RSS feeds?  This change adds support for including a Style sheet in the XML.

  $feed->addStyle("<css url>", "<optional media specification - defaults to screen>")

Thank you,
Craig