### PR TITLE
Remove unnecessary empty elements

### DIFF
--- a/src/Suin/RSSWriter/Item.php
+++ b/src/Suin/RSSWriter/Item.php
@@ -126,7 +126,9 @@ class Item implements ItemInterface
             $xml->addChild('title', $this->title);
         }
 
-        $xml->addChild('link', $this->url);
+        if ($this->url) {
+            $xml->addChild('link', $this->url);
+        }
 
         if ($this->preferCdata) {
             $xml->addCdataChild('description', $this->description);

--- a/src/Suin/RSSWriter/Item.php
+++ b/src/Suin/RSSWriter/Item.php
@@ -120,20 +120,25 @@ class Item implements ItemInterface
     {
         $xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8" ?><item></item>', LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_ERR_FATAL);
 
-        if ($this->preferCdata) {
-            $xml->addCdataChild('title', $this->title);
-        } else {
-            $xml->addChild('title', $this->title);
+        if ($this->title) {
+            if ($this->preferCdata) {
+                $xml->addCdataChild('title', $this->title);
+            } else {
+                $xml->addChild('title', $this->title);
+            }
         }
 
         if ($this->url) {
             $xml->addChild('link', $this->url);
         }
 
-        if ($this->preferCdata) {
-            $xml->addCdataChild('description', $this->description);
-        } else {
-            $xml->addChild('description', $this->description);
+        // At least one of <title> or <description> must be present
+        if ($this->description || ! $this->title) {
+            if ($this->preferCdata) {
+                $xml->addCdataChild('description', $this->description);
+            } else {
+                $xml->addChild('description', $this->description);
+            }
         }
 
         if ($this->contentEncoded) {

--- a/tests/Suin/RSSWriter/ItemTest.php
+++ b/tests/Suin/RSSWriter/ItemTest.php
@@ -51,7 +51,6 @@ class ItemTest extends TestCase
             <description/>
             <item>
               <title/>
-              <link/>
               <description/>
               <content:encoded><![CDATA[<div>contents</div>]]></content:encoded>
             </item>

--- a/tests/Suin/RSSWriter/ItemTest.php
+++ b/tests/Suin/RSSWriter/ItemTest.php
@@ -50,7 +50,6 @@ class ItemTest extends TestCase
             <link/>
             <description/>
             <item>
-              <title/>
               <description/>
               <content:encoded><![CDATA[<div>contents</div>]]></content:encoded>
             </item>


### PR DESCRIPTION
As per the RSS specification, there is no need to display empty `<link/>` in `<item>`. 

We could also skip empty `<title>` or `<description>` in `<item>`.