### PR TITLE
Add itunes:category support to channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ $channel
     ->feedUrl('http://blog.example.com/rss')
     ->language('en-US')
     ->copyright('Copyright 2012, Foo Bar')
+    ->itunescategory('History')
     ->pubDate(strtotime('Tue, 21 Aug 2012 19:50:37 +0900'))
     ->lastBuildDate(strtotime('Tue, 21 Aug 2012 19:50:37 +0900'))
     ->ttl(60)

--- a/src/Suin/RSSWriter/Channel.php
+++ b/src/Suin/RSSWriter/Channel.php
@@ -113,6 +113,12 @@ class Channel implements ChannelInterface
         return $this;
     }
 
+    public function itunescategory($itunescategory)
+    {
+        $this->itunescategory = $itunescategory;
+        return $this;
+    }
+
     /**
      * Set channel published date
      * @param int $pubDate Unix timestamp
@@ -207,6 +213,11 @@ class Channel implements ChannelInterface
 
         if ($this->copyright !== null) {
             $xml->addChild('copyright', $this->copyright);
+        }
+
+        if($this->itunescategory !== null) {
+            $link = $xml->addChild("itunes:itunes:category");
+            $link->addAttribute('text',$this->itunescategory);
         }
 
         if ($this->pubDate !== null) {


### PR DESCRIPTION
Added the itunes:category tag. Any text can be set as the category.